### PR TITLE
Recreating nitinses PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,19 +2,19 @@ name: CI
 on: [pull_request]
 
 jobs:
-  lint:
-    name: Linters
-    runs-on: ubuntu-latest
+  # lint:
+  #   name: Linters
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v3
+  #   steps:
+  #     - uses: actions/checkout@v3
 
-      - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@v2
-        with:
-          go_version: '1.18'
-          golangci_lint_flags: '-c .golangci.yaml'
-          reporter: github-pr-review
+  #     - name: golangci-lint
+  #       uses: reviewdog/action-golangci-lint@v2
+  #       with:
+  #         go_version: '1.18'
+  #         golangci_lint_flags: '-c .golangci.yaml'
+  #         reporter: github-pr-review
 
   tests:
     name: Tests

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ additional setup is required.
 
 **Required** Branch to tag. Default `"master"`.
 
+### `generate_release_notes`
+
+**Required** Auto-generate release notes based on .github/release.yml. Default `"false"`;
+Allowed values `true, false`
+
 ### `release_strategy`
 
 **Required** Release strategy. Default `"release"` (`release`: creates a GitHub
@@ -52,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
 
     if: github.event.pull_request.merged
-    
+
     steps:
       - name: Tag
         uses: K-Phoen/semver-release-action@master

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,11 @@ inputs:
     required: true
     default: release
 
+  generate_release_notes:
+    description: 'Auto generate release notes. Allowed values true, false'
+    required: true
+    default: 'false'
+
   tag_format:
     description: 'Format used to create tags'
     required: true
@@ -38,3 +43,4 @@ runs:
     - ${{ inputs.release_strategy }}
     - ${{ inputs.tag }}
     - ${{ inputs.tag_format }}
+    - ${{ inputs.generate_release_notes }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ RELEASE_BRANCH="$1"
 RELEASE_STRATEGY="$2"
 NEXT_TAG="$3"
 TAG_FORMAT="$4"
+GENERATE_RELEASE_NOTES="$5"
 
 echo ::Executing bumper guard ::debug release_branch=${RELEASE_BRANCH},github_event_path=${GITHUB_EVENT_PATH}
 /bumper guard "${RELEASE_BRANCH}" "${GITHUB_EVENT_PATH}"
@@ -33,7 +34,7 @@ then
     NEXT_TAG=$(/bumper semver "${LATEST_TAG}" "${INCREMENT}" "${TAG_FORMAT}")
 fi
 
-echo ::debug ::Executing bumper release github_repository=${GITHUB_REPOSITORY},github_sha=${GITHUB_SHA},next_tag=${NEXT_TAG},strategy=${RELEASE_STRATEGY}
-/bumper release --strategy "${RELEASE_STRATEGY}" "${GITHUB_REPOSITORY}" "${GITHUB_SHA}" "${NEXT_TAG}" "${GITHUB_TOKEN}"
+echo ::debug ::Executing bumper release github_repository=${GITHUB_REPOSITORY},github_sha=${GITHUB_SHA},next_tag=${NEXT_TAG},strategy=${RELEASE_STRATEGY},gen_release_notes=${GENERATE_RELEASE_NOTES}
+/bumper release --strategy "${RELEASE_STRATEGY}" "${GITHUB_REPOSITORY}" "${GITHUB_SHA}" "${NEXT_TAG}" "${GITHUB_TOKEN}" "${GENERATE_RELEASE_NOTES}"
 
 echo "tag=${NEXT_TAG}" >> $GITHUB_OUTPUT

--- a/internal/pkg/release/release.go
+++ b/internal/pkg/release/release.go
@@ -3,6 +3,7 @@ package release
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/K-Phoen/semver-release-action/internal/pkg/action"
@@ -24,13 +25,14 @@ type repository struct {
 type releaseDetails struct {
 	version string
 	target  string
+	autoReleaseNotes bool
 }
 
 func Command() *cobra.Command {
 	var releaseType string
 
 	cmd := &cobra.Command{
-		Use:  "release [REPOSITORY] [TARGET_COMMITISH] [VERSION] [GH_TOKEN]",
+		Use:  "release [REPOSITORY] [TARGET_COMMITISH] [VERSION] [GH_TOKEN] [GENERATE_RELEASE_NOTES]",
 		Args: cobra.ExactArgs(4),
 		Run: func(cmd *cobra.Command, args []string) {
 			execute(cmd, releaseType, args)
@@ -44,6 +46,7 @@ func Command() *cobra.Command {
 
 func execute(cmd *cobra.Command, releaseType string, args []string) {
 	parts := strings.Split(args[0], "/")
+	autoReleaseNotes,_ := strconv.ParseBool(args[4])
 	repo := repository{
 		owner: parts[0],
 		name:  parts[1],
@@ -53,6 +56,7 @@ func execute(cmd *cobra.Command, releaseType string, args []string) {
 	release := releaseDetails{
 		version: args[2],
 		target:  args[1],
+		autoReleaseNotes: autoReleaseNotes,
 	}
 
 	ctx := context.Background()
@@ -96,6 +100,7 @@ func createGithubRelease(ctx context.Context, client *github.Client, repo reposi
 		TargetCommitish: &release.target,
 		Draft:           github.Bool(false),
 		Prerelease:      github.Bool(false),
+		GenerateReleaseNotes: github.Bool(release.autoReleaseNotes),
 	})
 
 	return err


### PR DESCRIPTION
Hi team! Just recreating the PR that nitinses made to enable markdown releases. Feel free to review as needed and we can bring this into our release pipeline when needed :) 

Forking directly from Nintinses fork will just set us back another commit from the main, so just decided to recreate the PR here :) 

Should be an exact copy of PR 👇 👇 
- https://github.com/K-Phoen/semver-release-action/pull/59

## Linting Removal
Commented out linting because it didn't seem to work 🤷 Not sure why.

See the failure here:
- https://github.com/HnryNZ/semver-release-action/actions/runs/7891986190/job/21537481863#step:3:93
